### PR TITLE
Add support for local types

### DIFF
--- a/idarling/core/hooks.py
+++ b/idarling/core/hooks.py
@@ -121,6 +121,23 @@ class IDBHooks(Hooks, ida_idp.IDB_Hooks):
         self._send_event(TiChangedEvent(ea, type))
         return 0
 
+    def local_types_changed(self):
+        local_types = []
+        logger.debug("local_types_changed")
+        for ordinal in range(1,ida_typeinf.get_ordinal_qty(None)):
+            ret = ida_typeinf.idc_get_local_type_raw(ordinal)
+            if ret is not None:
+                type_str, fields_str = ret
+                type_name = ida_typeinf.get_numbered_type_name(ida_typeinf.cvar.idati,ordinal)
+                cur_ti = ida_typeinf.tinfo_t()
+                cur_ti.deserialize(ida_typeinf.cvar.idati, type_str, fields_str)
+                type_serialized = cur_ti.serialize()
+                local_types.append((type_serialized[0],type_serialized[1],type_name))
+            else:
+                local_types.append(None)
+        self._send_event(LocalTypesChangedEvent(local_types))
+        return 0
+
     def op_type_changed(self, ea, n):
         def gather_enum_info(ea, n):
             id = ida_bytes.get_enum_id(ea, n)[0]


### PR DESCRIPTION
The original implemention does not sync the local types, causing users got different slot number for the same structure, leading to chaos in Hex-Rays.