### PR TITLE
Fix database foreign key definitions

### DIFF
--- a/idarling/shared/database.py
+++ b/idarling/shared/database.py
@@ -49,7 +49,7 @@ class Database(object):
             'repo text not null',
             'name text not null',
             'date text not null',
-            'foreign key(repo) references repos(repo)',
+            'foreign key(repo) references repos(name)',
             'primary key(repo, name)',
         ])
         self._create('events', [
@@ -58,7 +58,7 @@ class Database(object):
             'tick integer not null',
             'dict text not null',
             'foreign key(repo) references repos(name)',
-            'foreign key(branch) references branches(name)',
+            'foreign key(repo, branch) references branches(repo, name)',
             'primary key(repo, branch, tick)',
         ])
 


### PR DESCRIPTION
Running `pragma foreign_key_check;` in sqlite reports "foreign key mismatch" -- this patch updates foreign key definitions to fix that error.