### PR TITLE
Save config of servers in a dict instead of tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ you should be able to access the following menus:
 - File --> Save to server
 ```
 
+## FAQ
+
+* Where is my old servers?
+
+In commit 08eca13d4ecd51cd518cb54546f971e3b43edf04 the config file name is changed
+from `state.json` to `config.json`, to enhance the config file storage. Thus all
+old servers are not displayed in your server list. But don't worry, you can still
+find them in your previous config file. The path of your config file depends
+your platform. For example, under Linux, the path should be: 
+`$HOME/.idapro/idarling/files/state.json`
+You can still find your old servers there.
+
 # Thanks
 
 This project is inspired by [Sol[IDA]rity](https://solidarity.re/). It started

--- a/idarling/interface/dialogs.py
+++ b/idarling/interface/dialogs.py
@@ -522,7 +522,8 @@ class NetworkSettingsDialog(QDialog):
         self._plugin.core.servers = servers
         rowCount = self._serversTable.rowCount()
         self._serversTable.insertRow(rowCount)
-        newServer = QTableWidgetItem('%s:%d' % (server["host"], server["port"]))
+        newServer = QTableWidgetItem('%s:%d' %
+                                     (server["host"], server["port"]))
         newServer.setData(Qt.UserRole, server)
         newServer.setFlags(newServer.flags() & ~Qt.ItemIsEditable)
         self._serversTable.setItem(rowCount, 0, newServer)

--- a/idarling/interface/dialogs.py
+++ b/idarling/interface/dialogs.py
@@ -26,7 +26,7 @@ from PyQt5.QtWidgets import (QDialog, QHBoxLayout, QVBoxLayout, QGridLayout,
                              QCheckBox)
 
 from ..shared.commands import GetRepositories, GetBranches, \
-                               NewRepository, NewBranch
+    NewRepository, NewBranch
 from ..shared.models import Repository, Branch
 
 logger = logging.getLogger('IDArling.Interface')
@@ -173,6 +173,7 @@ class OpenDialog(QDialog):
         """
         Refreshes the table of branches.
         """
+
         def createItem(text, branch):
             item = QTableWidgetItem(text)
             item.setData(Qt.UserRole, branch)
@@ -180,6 +181,7 @@ class OpenDialog(QDialog):
             if branch.tick == -1:
                 item.setFlags(item.flags() & ~Qt.ItemIsEnabled)
             return item
+
         self._branchesTable.setRowCount(len(self._branches))
         for i, branch in enumerate(self._branches):
             self._branchesTable.setItem(i, 0, createItem(branch.name, branch))
@@ -442,7 +444,7 @@ class NetworkSettingsDialog(QDialog):
         self._serversTable = QTableWidget(len(servers), 1, self)
         self._serversTable.setHorizontalHeaderLabels(("Servers",))
         for i, server in enumerate(servers):
-            item = QTableWidgetItem('%s:%d' % (server.host, server.port))
+            item = QTableWidgetItem('%s:%d' % (server["host"], server["port"]))
             item.setData(Qt.UserRole, server)
             item.setFlags(item.flags() & ~Qt.ItemIsEditable)
             self._serversTable.setItem(i, 0, item)
@@ -514,15 +516,13 @@ class NetworkSettingsDialog(QDialog):
 
         :param dialog: the add server dialog
         """
-        host, port, no_ssl = dialog.get_result()
-        Server = namedtuple('Server', ['host', 'port', 'no_ssl'])
-        server = Server(host, port, no_ssl)
+        server = dialog.get_result()
         servers = self._plugin.core.servers
         servers.append(server)
         self._plugin.core.servers = servers
         rowCount = self._serversTable.rowCount()
         self._serversTable.insertRow(rowCount)
-        newServer = QTableWidgetItem('%s:%d' % (server.host, server.port))
+        newServer = QTableWidgetItem('%s:%d' % (server["host"], server["port"]))
         newServer.setData(Qt.UserRole, server)
         newServer.setFlags(newServer.flags() & ~Qt.ItemIsEditable)
         self._serversTable.setItem(rowCount, 0, newServer)
@@ -534,15 +534,13 @@ class NetworkSettingsDialog(QDialog):
 
         :param dialog: the edit server dialog
         """
-        host, port, no_ssl = dialog.get_result()
-        Server = namedtuple('Server', ['host', 'port', 'no_ssl'])
-        server = Server(host, port, no_ssl)
+        server = dialog.get_result()
         servers = self._plugin.core.servers
         item = self._serversTable.selectedItems()[0]
         servers[item.row()] = server
         self._plugin.core.servers = servers
 
-        item.setText('%s:%d' % (server.host, server.port))
+        item.setText('%s:%d' % (server["host"], server["port"]))
         item.setData(Qt.UserRole, server)
         item.setFlags(item.flags() & ~Qt.ItemIsEditable)
         self.update()
@@ -600,9 +598,9 @@ class ServerInfoDialog(QDialog):
         layout.addWidget(self._noSSLCheckbox)
 
         if server is not None:
-            self._serverName.setText(server.host)
-            self._serverPort.setText(str(server.port))
-            self._noSSLCheckbox.setChecked(server.no_ssl)
+            self._serverName.setText(server["host"])
+            self._serverPort.setText(str(server["port"]))
+            self._noSSLCheckbox.setChecked(server["no_ssl"])
 
         downSide = QWidget(self)
         buttonsLayout = QHBoxLayout(downSide)
@@ -620,6 +618,9 @@ class ServerInfoDialog(QDialog):
 
         :return: the result
         """
-        return (self._serverName.text() or "127.0.0.1",
-                int(self._serverPort.text() or "31013"),
-                self._noSSLCheckbox.isChecked())
+        new_server = {
+            "host": self._serverName.text() or "127.0.0.1",
+            "port": int(self._serverPort.text() or "31013"),
+            "no_ssl": self._noSSLCheckbox.isChecked()
+        }
+        return new_server

--- a/idarling/interface/widgets.py
+++ b/idarling/interface/widgets.py
@@ -79,7 +79,7 @@ class StatusWidget(QWidget):
         if self._server is None:
             server = '&lt;no server&gt;'
         else:
-            server = '%s:%d' % (self._server.host, self._server.port)
+            server = '%s:%d' % (self._server["host"], self._server["port"])
         textFormat = '%s | %s -- <span style="color: %s;">%s</span>'
         self._textWidget.setText(textFormat % (self._plugin.description(),
                                                server, color, text))
@@ -147,19 +147,17 @@ class StatusWidget(QWidget):
 
             def serverActionTriggered(serverAction):
                 isConnected = self._plugin.network.connected \
-                    and server.host == currentServer.host \
-                    and server.port == currentServer.port
+                    and server["host"] == currentServer["host"] \
+                    and server["port"] == currentServer["port"]
                 self._plugin.network.stop_server()
                 if not isConnected:
-                    self._plugin.network.connect(serverAction._server.host,
-                                                 serverAction._server.port,
-                                                 serverAction._server.no_ssl)
+                    self._plugin.network.connect(serverAction._server)
 
             for server in self._plugin.core.servers:
                 isConnected = self._plugin.network.connected \
-                              and server.host == currentServer.host \
-                              and server.port == currentServer.port
-                serverText = '%s:%d' % (server.host, server.port)
+                              and server["host"] == currentServer["host"] \
+                              and server["port"] == currentServer["port"]
+                serverText = '%s:%d' % (server["host"], server["port"])
                 serverAction = QAction(serverText, menu)
                 serverAction._server = server
                 serverAction.setCheckable(True)

--- a/idarling/network/network.py
+++ b/idarling/network/network.py
@@ -58,7 +58,7 @@ class Network(Module):
         self.disconnect()
         return True
 
-    def connect(self, host, port, no_ssl=False):
+    def connect(self, server):
         """
         Connect to the specified host and port.
 
@@ -70,11 +70,13 @@ class Network(Module):
         # Make sure we're not already connected
         if self.connected:
             return False
+        self._server = server.copy()  # Copy in case of source being changed
+        host = self._server["host"]
+        port = self._server["port"]
+        no_ssl = self._server["port"]
 
         # Create a client
         self._client = Client(self._plugin)
-        Server = collections.namedtuple('Server', ['host', 'port', 'no_ssl'])
-        self._server = Server(host, port, no_ssl)
 
         # Do the actual connection process
         logger.info("Connecting to %s:%d..." % (host, port))
@@ -152,7 +154,8 @@ class Network(Module):
         if not server.start('0.0.0.0'):
             return False
         self._integrated = server
-        return self.connect('127.0.0.1', server.port, True)
+        integrated_arg = {"host": "127.0.0.1", "port": server.port, "no_ssl": True}
+        return self.connect(integrated_arg)
 
     def stop_server(self):
         """

--- a/idarling/network/network.py
+++ b/idarling/network/network.py
@@ -154,7 +154,11 @@ class Network(Module):
         if not server.start('0.0.0.0'):
             return False
         self._integrated = server
-        integrated_arg = {"host": "127.0.0.1", "port": server.port, "no_ssl": True}
+        integrated_arg = {
+            "host": "127.0.0.1",
+            "port": server.port,
+            "no_ssl": True
+        }
         return self.connect(integrated_arg)
 
     def stop_server(self):


### PR DESCRIPTION
As we have discussed in issue #21, use `tuple` is not an elegent way for us, thus I changed it to `dict`.

The code is not well tested. I have only tested with IP as hostname, and try to connect/disconnect it. Seems it works fine.