### PR TITLE
Fix local_type bug if t is None

### DIFF
--- a/idarling/core/events.py
+++ b/idarling/core/events.py
@@ -326,14 +326,14 @@ class LocalTypesChangedEvent(Event):
                 ida_typeinf.alloc_type_ordinals(None, missing_ord)
 
         for t in local_type:
-            logger.debug("Processing: %s", str(t))
-            alloc_oridinal(t[0])
-
-            # Can't change some local types if not delete them first
-            # Example: struct aaa{int a;}'
-            ida_typeinf.del_numbered_type(None, t[0])
-
             if t is not None:
+                logger.debug("Processing: %s", str(t))
+                alloc_oridinal(t[0])
+
+                # Can't change some local types if not delete them first
+                # Example: struct aaa{int a;}'
+                ida_typeinf.del_numbered_type(None, t[0])
+
                 cur_tinfo = ida_typeinf.tinfo_t()
                 cur_tinfo.deserialize(None, t[1], t[2])
                 logger.debug("set_numbered_type ret: %d",


### PR DESCRIPTION
Bug log

```
[19:57:02][DEBUG] Sending packet: LocalTypesChangedEvent(...)
[19:57:02][DEBUG] set_numbered_type ret: 0
[19:57:02][DEBUG] Processing: None
[19:57:02][WARNING] Error while calling event
[19:57:02][ERROR] 'NoneType' object has no attribute '__getitem__'
Traceback (most recent call last):
  File "/Applications/IDA Pro 7.1/ida64.app/Contents/MacOS/plugins/idarling/network/client.py", line 57, in recv_packet
    packet()
  File "/Applications/IDA Pro 7.1/ida64.app/Contents/MacOS/plugins/idarling/core/events.py", line 330, in __call__
    alloc_oridinal(t[0])
TypeError: 'NoneType' object has no attribute '__getitem__'
[19:57:02][WARNING] De-synchronization detected!
```