### PR TITLE
Fix importing QApplication

### DIFF
--- a/idarling/interface/interface.py
+++ b/idarling/interface/interface.py
@@ -15,7 +15,8 @@ import logging
 from PyQt5.QtCore import QObject, Qt
 from PyQt5.QtGui import QShowEvent, QPixmap
 from PyQt5.QtWidgets import qApp, QMainWindow,\
-                            QDialog, QGroupBox, QLabel
+                            QDialog, QGroupBox, QLabel,\
+                            QApplication
 
 from ..module import Module
 from .actions import OpenAction, SaveAction


### PR DESCRIPTION
Maybe forget to import this one?
```
[ERROR] Failed to initialize
[ERROR] Failed to initialize	(plugin:init)
[ERROR] global name 'QApplication' is not defined
Traceback (most recent call last):
  File "C:/Program Files/IDA 7.0/plugins\idarling\plugin.py", line 119, in init
    self._init()
  File "C:/Program Files/IDA 7.0/plugins\idarling\plugin.py", line 137, in _init
    self._interface.install()
  File "C:/Program Files/IDA 7.0/plugins\idarling\module.py", line 38, in install
    return self._install()
  File "C:/Program Files/IDA 7.0/plugins\idarling\interface\interface.py", line 82, in _install
    self._install_our_icon()
  File "C:/Program Files/IDA 7.0/plugins\idarling\interface\interface.py", line 110, in _install_our_icon
    QApplication.instance().installEventFilter(self._eventFilter)
NameError: global name 'QApplication' is not defined
```