### PR TITLE
Fix Windows support

### DIFF
--- a/idarling/shared/discovery.py
+++ b/idarling/shared/discovery.py
@@ -81,8 +81,9 @@ class ClientsDiscovery(QObject):
         request = request.encode("utf-8")
         while len(request):
             try:
+                self._socket.setblocking(0)
                 sent = self._socket.sendto(
-                    request, socket.MSG_DONTWAIT, ("<broadcast>", 31013)
+                    request, 0, ("<broadcast>", 31013)
                 )
                 request = request[sent:]
             except socket.error as e:


### PR DESCRIPTION
In Windows socket don't have the MSG_DONTWAIT attribute.
See Stackoverflow post for more info: https://stackoverflow.com/questions/54071217/attributeerror-module-socket-has-no-attribute-msg-dontwait