### PR TITLE
Use lru_cache for make_icon, fix calls

### DIFF
--- a/idarling/interface/filter.py
+++ b/idarling/interface/filter.py
@@ -93,7 +93,7 @@ class EventFilter(QObject):
         menu.addAction(everyone)
 
         menu.addSeparator()
-        template = QImage(self._plugin.plugin_resource("user.png"))
+        template = self._plugin.plugin_resource("user.png")
 
         def create_action(name, color):
             action = QAction(name, menu)

--- a/idarling/interface/widget.py
+++ b/idarling/interface/widget.py
@@ -11,7 +11,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 import colorsys
-from functools import partial
+from functools import partial, lru_cache
 import time
 
 from PyQt5.QtCore import QPoint, QRect, QSize, Qt, QTimer
@@ -44,6 +44,7 @@ class StatusWidget(QWidget):
         return 0xFF000000 | r | g | b
 
     @staticmethod
+    @lru_cache(maxsize=32)
     def make_icon(template, color):
         """
         Create an icon for the specified user color. It will be used to
@@ -182,7 +183,7 @@ class StatusWidget(QWidget):
         self._users_text_widget.adjustSize()
 
         # Update the icon of the users widget
-        template = QImage(self._plugin.plugin_resource("user.png"))
+        template = self._plugin.plugin_resource("user.png")
         color = self._plugin.config["user"]["color"]
         pixmap = self.make_icon(template, color)
         pixmap_height = self._servers_text_widget.sizeHint().height()

--- a/idarling/network/client.py
+++ b/idarling/network/client.py
@@ -125,7 +125,7 @@ class Client(ClientSocket):
         if packet.silent:
             return
         text = "%s joined the session" % packet.name
-        template = QImage(self._plugin.plugin_resource("user.png"))
+        template = self._plugin.plugin_resource("user.png")
         icon = StatusWidget.make_icon(template, packet.color)
         self._plugin.interface.show_invite(text, icon)
 
@@ -139,7 +139,7 @@ class Client(ClientSocket):
         if packet.silent:
             return
         text = "%s left the session" % packet.name
-        template = QImage(self._plugin.plugin_resource("user.png"))
+        template = self._plugin.plugin_resource("user.png")
         icon = StatusWidget.make_icon(template, user["color"])
         self._plugin.interface.show_invite(text, icon)
 


### PR DESCRIPTION
The `make_icon` function is called regularly but is a bit CPU expensive, use `lru_cache` to avoid useless recomputations.